### PR TITLE
added 1st abr capybara test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :development, :test do
   gem "rspec-rails", "~> 3.9"
   gem 'rspec-collection_matchers'
   gem 'rspec-activemodel-mocks'
+  gem 'capybara'
   
   gem "rr", "= 0.10.11"
   
@@ -75,6 +76,7 @@ group :development, :test do
   gem "database_cleaner"
   gem "shoulda"
   gem 'simplecov', :require => false
+  gem 'webdrivers'
   
   #gem "treetop", "= 1.4.10"
   # gem "selenium-client", "= 1.2.16"

--- a/spec/features/abr_spec.rb
+++ b/spec/features/abr_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature 'ABR' do
+
+  scenario 'positive end to end', js: true do
+    visit '/absentee'
+    fill_in 'Email Address', with: 'registrant@mail.com'
+    fill_in 'ZIP Code', with: 99801
+    # click_on doesn't work - we use <button> inside <a>
+    find(:button, text: 'Next Step').click
+
+    fill_in 'First Name', with: 'John'
+    fill_in 'Last Name', with: 'Smith'
+    fill_in 'Street number', with: 120
+    fill_in 'Street name', with: '4th St'
+    fill_in 'City', with: 'Juneau'
+
+    fill_in 'abr_date_of_birth_month', with: 1
+    fill_in 'abr_date_of_birth_day', with: 2
+    fill_in 'abr_date_of_birth_year', with: 2000
+
+    find(:button, text: 'Next Step').click
+    expect(page).to have_content('You can request an Absentee Ballot online directly with the state of Alaska')
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -120,7 +120,7 @@ RSpec.configure do |config|
     
   end
   
-  
+  Capybara.javascript_driver = ENV['DEBUG'] ? :selenium_chrome : :selenium_chrome_headless
 end
 
 def mock_admin_logged_in


### PR DESCRIPTION
Updated gems + minimalistic spec.
Webdrivers gem installs any required web drivers and the required browser binary is expected to be installed. I set it to chrome and can be switched to firefox if needed.

Feature specs use `rack_test` driver if `js: true` meta is not added ( we can set it to selenium-<...> by default)

I've skipped Gemfile.lock to hide MySQL 0.4.10 upgrade (can't compile it for a modern MySQL client)

![image](https://user-images.githubusercontent.com/8615227/88616254-4bc3a080-d059-11ea-8cd7-b163cacdcb84.png)
