### PR TITLE
Allow state text overrides

### DIFF
--- a/app/assets/stylesheets/abr-form-fields.scss
+++ b/app/assets/stylesheets/abr-form-fields.scss
@@ -119,7 +119,7 @@
     li {
       &.half,
       &.three-quarter, 
-      &.quarter,
+      &.quarter
       {
         display:block;
         width:100%;

--- a/app/assets/stylesheets/abr-page.scss
+++ b/app/assets/stylesheets/abr-page.scss
@@ -1,0 +1,5 @@
+
+#header .header-text 
+{
+    font-size:36px;
+}

--- a/app/assets/stylesheets/registration2.scss
+++ b/app/assets/stylesheets/registration2.scss
@@ -912,7 +912,7 @@ body {
         font-size: 18px;        
       }
     }
-    @import 'abr-form-fields'
+    @import 'abr-form-fields';
   }
   
   
@@ -952,3 +952,7 @@ body {
 @import 'registration2-mobile';
 @import 'registration2-new-mobile-ui';
 @import 'registration2-signature-capture';
+
+body.abr-page {
+  @import 'abr-page';
+}

--- a/app/views/abrs/finish.html.haml
+++ b/app/views/abrs/finish.html.haml
@@ -16,7 +16,7 @@
 - elsif !@share_only && !@pdf_ready
   %h2= t('txt.abr.finish_pdf_delay_header', state_name: @abr.home_state_name)
 
-  = t('txt.abr.finish_pdf_delay').html_safe
+  = t("states.custom.#{@abr.i18n_key}.abr.finish_pdf_delay", default: t('txt.abr.finish_pdf_delay')).html_safe
 
   = t("states.custom.#{@abr.i18n_key}.abr.finish_pdf_delay_instructions", default: "").html_safe
 

--- a/app/views/abrs/state_online.html.haml
+++ b/app/views/abrs/state_online.html.haml
@@ -37,7 +37,7 @@
   - unless @abr.oabr_for_all?
     .intro-message
       %p.reject
-        = link_to I18n.t("states.custom.#{@abr.i18n_key}.skip_state_online_abr", default: I18n.t('txt.abr.skip_state_online_abr')), step_3_abr_path(@abr)
+        = link_to I18n.t("states.custom.#{@abr.i18n_key}.abr.skip_state_online_abr", default: I18n.t('txt.abr.skip_state_online_abr')), step_3_abr_path(@abr)
         
 
   

--- a/app/views/abrs/state_online.html.haml
+++ b/app/views/abrs/state_online.html.haml
@@ -37,7 +37,9 @@
   - unless @abr.oabr_for_all?
     .intro-message
       %p.reject
-        = link_to I18n.t('txt.abr.skip_state_online_abr'), step_3_abr_path(@abr)
+        = link_to I18n.t("states.custom.#{@abr.i18n_key}.skip_state_online_abr", default: I18n.t('txt.abr.skip_state_online_abr')), step_3_abr_path(@abr)
+        
+
   
   
     

--- a/app/views/abrs/step_3.html.haml
+++ b/app/views/abrs/step_3.html.haml
@@ -23,9 +23,9 @@
     
     })
   
-  %h2= t('txt.abr.step_3_header', {state: @abr.home_state_name})
+  %h2= t("states.custom.#{@abr.i18n_key}.step_3_header", default: t('txt.abr.step_3_header', {state: @abr.home_state_name}))
   .intro-message
-    = t('txt.abr.step_3_instructions').html_safe
+    = t("states.custom.#{@abr.i18n_key}.step_3_instructions", default:t('txt.abr.step_3_instructions')).html_safe
     %br
 
 

--- a/app/views/abrs/step_3.html.haml
+++ b/app/views/abrs/step_3.html.haml
@@ -23,9 +23,9 @@
     
     })
   
-  %h2= t("states.custom.#{@abr.i18n_key}.step_3_header", default: t('txt.abr.step_3_header', {state: @abr.home_state_name}))
+  %h2= t("states.custom.#{@abr.i18n_key}.abr.step_3_header", default: t('txt.abr.step_3_header', {state: @abr.home_state_name}))
   .intro-message
-    = t("states.custom.#{@abr.i18n_key}.step_3_instructions", default:t('txt.abr.step_3_instructions')).html_safe
+    = t("states.custom.#{@abr.i18n_key}.abr.step_3_instructions", default:t('txt.abr.step_3_instructions')).html_safe
     %br
 
 

--- a/app/views/abrs/step_3.html.haml
+++ b/app/views/abrs/step_3.html.haml
@@ -90,7 +90,7 @@
             %strong{style: "font-weight: bold"}= I18n.l @abr.date_of_birth, format: :long
             
           .declaration-text{style: "font-weight: bold; text-align: center"}
-            = t('txt.abr.step_3_deliver_via_email_instructions').html_safe
+            =  t("states.custom.#{@abr.i18n_key}.abr.step_3_deliver_via_email_instructions", default: t('txt.abr.step_3_deliver_via_email_instructions')).html_safe
           - confirm_label = t("states.custom.#{@abr.i18n_key}.abr.confirm_email_delivery", default: "")
           - confirm_label = nil if confirm_label.blank?
           = render partial: 'registrants/generic/checkbox', locals: {field_label: confirm_label, form: form, field: :confirm_email_delivery, class_name: "registrant-form__confirm_email_delivery__line", required: true, require_accepted: true}

--- a/app/views/layouts/abr.html.erb
+++ b/app/views/layouts/abr.html.erb
@@ -52,7 +52,7 @@
   <%= yield :head %>
 </head>
 
-<body class="<%= 'primary-partner' if @partner && @partner.primary? %> <%= 'new-mobile-ui' if @use_mobile_ui %>">
+<body class="abr-page <%= 'primary-partner' if @partner && @partner.primary? %> <%= 'new-mobile-ui' if @use_mobile_ui %>">
   <%- if @partner && !@partner.external_tracking_snippet.blank? %>
   <%= @partner.external_tracking_snippet.to_s.html_safe %>
   <%- end %>

--- a/app/views/layouts/abr.html.erb
+++ b/app/views/layouts/abr.html.erb
@@ -65,7 +65,7 @@
         <% end -%>
         <div class='header-text'>
           <%- if @abr && @abr.home_state_abbrev %>
-          <%= t 'txt.request_absentee_ballot_in', state_abbrev: @abr.home_state_abbrev %>
+          <%= I18n.t("states.custom.#{@abr.i18n_key}.request_absentee_ballot_in", default: I18n.t('txt.request_absentee_ballot_in'), state_abbrev: @abr.home_state_abbrev)%>
           <%- else%>
           <%= t 'txt.request_absentee_ballot' %>
           <%- end %>


### PR DESCRIPTION
This is the plumbing change that many of the other branches depend on.

Look for state specific keys, default to general

And adds the ABR specific stylesheet targeting content under body.abr-page

(also two misc scss syntax fixes which weren't causing problems, but weren't right)