### PR TITLE
PDF Assistance Reporting

### DIFF
--- a/app/helpers/registrant_methods.rb
+++ b/app/helpers/registrant_methods.rb
@@ -57,6 +57,12 @@ module RegistrantMethods
     attribute ? "Yes" : "No"
   end
   
+  def yes_no_nothing(attribute)
+    return nil if attribute.nil?
+
+    attribute ? "Yes" : "No"
+  end
+  
   def yes_no_localized(attribute)
     attribute ? I18n.t('yes', locale: self.locale) : I18n.t('no', locale: self.locale)
   end

--- a/app/models/registrant.rb
+++ b/app/models/registrant.rb
@@ -1470,7 +1470,7 @@ class Registrant < ActiveRecord::Base
   
   
   def pdf_is_esigned?
-    !skip_mail_with_esig? && !voter_signature_image.blank?
+    !skip_mail_with_esig? && voter_signature.present? && voter_signature_image.present?
   end
   
   VOTER_SIGNATURE_ATTRIBUTES = [

--- a/app/models/registrant.rb
+++ b/app/models/registrant.rb
@@ -240,7 +240,8 @@ class Registrant < ActiveRecord::Base
     "VR Application Status Details",
     "VR Application Status Imported DateTime",
     "Submitted Via State API",
-    "Submitted Signature to State API"
+    "Submitted Signature to State API",
+    "Requested Assistance",
   ]
   
   CSV_HEADER_EXTENDED = [
@@ -1819,6 +1820,7 @@ class Registrant < ActiveRecord::Base
       
       yes_no(submitted_via_state_api?),
       api_submitted_with_signature,
+      yes_no_nothing(requested_pdf_assistance?),
       
     ]
   end
@@ -2062,6 +2064,13 @@ class Registrant < ActiveRecord::Base
     end
   end
 
+  def requested_pdf_assistance?
+    if pdf_delivery && !pdf_is_esigned?
+      return true
+    end
+
+    nil
+  end
 
   private ###
 

--- a/app/models/registrant.rb
+++ b/app/models/registrant.rb
@@ -241,7 +241,6 @@ class Registrant < ActiveRecord::Base
     "VR Application Status Imported DateTime",
     "Submitted Via State API",
     "Submitted Signature to State API",
-    "Requested Assistance",
   ]
   
   CSV_HEADER_EXTENDED = [
@@ -269,7 +268,8 @@ class Registrant < ActiveRecord::Base
     "Over 18 Affirmation",
     "Preferred Language",
     "State Flow Status",
-    "State API Transaction ID"
+    "State API Transaction ID",
+    "Requested Assistance",
   ].flatten
   
   GROMMET_CSV_HEADER = [
@@ -1739,6 +1739,7 @@ class Registrant < ActiveRecord::Base
       grommet_preferred_language,
       state_flow_status,
       state_transaction_id,
+      yes_no_nothing(requested_pdf_assistance?),
     ].flatten(1)
   end
   
@@ -1820,7 +1821,6 @@ class Registrant < ActiveRecord::Base
       
       yes_no(submitted_via_state_api?),
       api_submitted_with_signature,
-      yes_no_nothing(requested_pdf_assistance?),
       
     ]
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -386,11 +386,11 @@ class Report < ActiveRecord::Base
     else
       @registrants_report_selector ||= partner.registrants.where(registrants_report_conditions)
     end
-    @registrants_report_selector.includes(:pdf_delivery, :voter_signature)
+    @registrants_report_selector.includes(:voter_signature)
   end
   
   def registrants_report_extended_selector
-    @registrants_report_extended_selector ||= registrants_report_selector.includes({:canvassing_shift_registrant => :canvassing_shift})    
+    @registrants_report_extended_selector ||= registrants_report_selector.includes(:pdf_delivery, {:canvassing_shift_registrant => :canvassing_shift})    
   end
   
   

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -386,6 +386,7 @@ class Report < ActiveRecord::Base
     else
       @registrants_report_selector ||= partner.registrants.where(registrants_report_conditions)
     end
+    @registrants_report_selector.includes(:pdf_delivery, :voter_signature)
   end
   
   def registrants_report_extended_selector

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1,5 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe Report, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:partner) { FactoryGirl.create :partner }
+  let(:report) { FactoryGirl.create :report, partner: partner, report_type: report_type }
+  let!(:registrants) { FactoryGirl.create_list :completed_registrant, 3, partner: partner }
+  let!(:reg_no_pdf_delivery) { registrants[0] }
+  let!(:reg_unsigned_pdf_delivery) { registrants[1].tap { |r| r.create_pdf_delivery } }
+  let!(:reg_esigned_pdf_delivery) { registrants[2].tap { |r| r.create_pdf_delivery; r.update!(voter_signature_image: '!')  } }
+
+  before do
+    allow(report).to receive(:write_report_file) do |_fn, contents|
+      @report = CSV.parse(contents)
+    end
+  end
+
+  context 'pdf_assistance' do
+    let(:report_type) { described_class::REGISTRANTS_REPORT_EXTENDED }
+    let(:column) { Registrant::CSV_HEADER_EXTENDED.index('Requested Assistance') }
+    let(:email) { Registrant::CSV_HEADER_EXTENDED.index('Email address') }
+
+    it 'includes pdf_assistance data' do
+      report.run
+      expect(report.status).to eq(Report::Status.complete.to_s)
+      expect(@report.size).to eq(registrants.size + 1)
+      expect(@report[0][column]).to eq('Requested Assistance')
+      expect(@report[2][email]).to eq(reg_unsigned_pdf_delivery.tell_email)
+      expect(@report[1][column]).to eq(nil)
+      expect(@report[2][column]).to eq('Yes')
+      expect(@report[3][column]).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
Extended version:
![image](https://user-images.githubusercontent.com/8615227/134611937-a5751009-b319-47c0-9f66-dac1372a6f54.png)


```
> rspec spec/models/report_spec.rb
Report
  pdf_assistance
    includes pdf_assistance data

Finished in 0.85842 seconds (files took 2.52 seconds to load)
1 example, 0 failures
```