### PR TITLE
increased rack's query key space limit 64K -> 256K

### DIFF
--- a/config/initializers/rack_initializer.rb
+++ b/config/initializers/rack_initializer.rb
@@ -1,0 +1,3 @@
+if Rack::Utils.respond_to?('key_space_limit=')
+  Rack::Utils.key_space_limit = 262144 
+end


### PR DESCRIPTION
translation's `#submit` submits too many keys as POST's body: 

https://github.com/rack/rack/blob/8be612ab949cf2eba7f4231ef17052a68315f911/lib/rack/query_parser.rb#L168-L170

```ruby
      def []=(key, value)
        @size += key.size if key && !@params.key?(key)
        raise RangeError, 'exceeded available parameter key space' if @size > @limit
```

increased the default limit from 64Kb to 256Kb, (for states/en the value is 70K locally). Probably need a better UI to fix it properly.