### PR TITLE
Add migration version to old migrations ActiveRecord::Migration

### DIFF
--- a/db/migrate/20090629205052_create_registrants.rb
+++ b/db/migrate/20090629205052_create_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class CreateRegistrants < ActiveRecord::Migration
+class CreateRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     create_table "registrants" do |t|
       t.string      "status"

--- a/db/migrate/20090714182329_create_geo_states.rb
+++ b/db/migrate/20090714182329_create_geo_states.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class CreateGeoStates < ActiveRecord::Migration
+class CreateGeoStates < ActiveRecord::Migration[4.2]
   def self.up
     create_table "geo_states" do |t|
       t.string "name", :limit => 21

--- a/db/migrate/20090720222522_create_partners.rb
+++ b/db/migrate/20090720222522_create_partners.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class CreatePartners < ActiveRecord::Migration
+class CreatePartners < ActiveRecord::Migration[4.2]
   def self.up
     create_table "partners" do |t|
       t.string    "username",           :null => false

--- a/db/migrate/20090811003128_create_delayed_jobs.rb
+++ b/db/migrate/20090811003128_create_delayed_jobs.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class CreateDelayedJobs < ActiveRecord::Migration
+class CreateDelayedJobs < ActiveRecord::Migration[4.2]
   def self.up
     create_table "delayed_jobs", :force => true do |t|
       t.integer  "priority", :default => 0

--- a/db/migrate/20090818174503_add_abandoned_to_registrant.rb
+++ b/db/migrate/20090818174503_add_abandoned_to_registrant.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddAbandonedToRegistrant < ActiveRecord::Migration
+class AddAbandonedToRegistrant < ActiveRecord::Migration[4.2]
   def self.up
     add_column "registrants", "abandoned", :boolean, :default => false, :null => false
   end

--- a/db/migrate/20090821222639_add_volunteer_option.rb
+++ b/db/migrate/20090821222639_add_volunteer_option.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddVolunteerOption < ActiveRecord::Migration
+class AddVolunteerOption < ActiveRecord::Migration[4.2]
   def self.up
     add_column :partners, :ask_for_volunteers, :boolean
     add_column :registrants, :volunteer, :boolean

--- a/db/migrate/20090826003717_add_party_tooltip_to_state_localization.rb
+++ b/db/migrate/20090826003717_add_party_tooltip_to_state_localization.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddPartyTooltipToStateLocalization < ActiveRecord::Migration
+class AddPartyTooltipToStateLocalization < ActiveRecord::Migration[4.2]
   def self.up
     add_column :state_localizations, :party_tooltip, :string, :limit => 1024
   end

--- a/db/migrate/20090827183521_add_index_on_state_localization_state.rb
+++ b/db/migrate/20090827183521_add_index_on_state_localization_state.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddIndexOnStateLocalizationState < ActiveRecord::Migration
+class AddIndexOnStateLocalizationState < ActiveRecord::Migration[4.2]
   def self.up
     add_index :state_localizations, :state_id
   end

--- a/db/migrate/20100317175214_add_tracking_source_to_registrant.rb
+++ b/db/migrate/20100317175214_add_tracking_source_to_registrant.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddTrackingSourceToRegistrant < ActiveRecord::Migration
+class AddTrackingSourceToRegistrant < ActiveRecord::Migration[4.2]
   def self.up
     add_column "registrants", "tracking_source", :string
   end

--- a/db/migrate/20100317234148_add_sub18_to_state_localizations.rb
+++ b/db/migrate/20100317234148_add_sub18_to_state_localizations.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddSub18ToStateLocalizations < ActiveRecord::Migration
+class AddSub18ToStateLocalizations < ActiveRecord::Migration[4.2]
   def self.up
     add_column "state_localizations", "sub_18", :string
   end

--- a/db/migrate/20100318003818_add_under18_flags_to_registrants.rb
+++ b/db/migrate/20100318003818_add_under18_flags_to_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddUnder18FlagsToRegistrants < ActiveRecord::Migration
+class AddUnder18FlagsToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     remove_column "registrants", "ineligible_attest"
     add_column    "registrants", "under_18_ok", :boolean

--- a/db/migrate/20100322170824_add_age_to_registrant.rb
+++ b/db/migrate/20100322170824_add_age_to_registrant.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddAgeToRegistrant < ActiveRecord::Migration
+class AddAgeToRegistrant < ActiveRecord::Migration[4.2]
   class Registrant < ActiveRecord::Base
     def calculate_age!
       now = created_at.to_date

--- a/db/migrate/20100323171029_add_official_party_name_to_registrants.rb
+++ b/db/migrate/20100323171029_add_official_party_name_to_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddOfficialPartyNameToRegistrants < ActiveRecord::Migration
+class AddOfficialPartyNameToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     add_column "registrants", "official_party_name", :string
     add_index  "registrants", "official_party_name"

--- a/db/migrate/20100325190624_add_widget_image_to_partners.rb
+++ b/db/migrate/20100325190624_add_widget_image_to_partners.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddWidgetImageToPartners < ActiveRecord::Migration
+class AddWidgetImageToPartners < ActiveRecord::Migration[4.2]
   def self.up
     add_column "partners", "widget_image", :string
 

--- a/db/migrate/20100331171944_add_logo_to_partner.rb
+++ b/db/migrate/20100331171944_add_logo_to_partner.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddLogoToPartner < ActiveRecord::Migration
+class AddLogoToPartner < ActiveRecord::Migration[4.2]
   def self.up
     add_column "partners", "logo_file_name", :string
     add_column "partners", "logo_content_type", :string

--- a/db/migrate/20100401172422_remove_partner_logo_image_url.rb
+++ b/db/migrate/20100401172422_remove_partner_logo_image_url.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class RemovePartnerLogoImageUrl < ActiveRecord::Migration
+class RemovePartnerLogoImageUrl < ActiveRecord::Migration[4.2]
   def self.up
     remove_column "partners", "logo_image_url"
   end

--- a/db/migrate/20100406180052_rename_sos_phone_to_sos_url.rb
+++ b/db/migrate/20100406180052_rename_sos_phone_to_sos_url.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class RenameSosPhoneToSosUrl < ActiveRecord::Migration
+class RenameSosPhoneToSosUrl < ActiveRecord::Migration[4.2]
   def self.up
     add_column "geo_states", "registrar_url", :string
   end

--- a/db/migrate/20100416000329_add_pdf_ready_to_registrants.rb
+++ b/db/migrate/20100416000329_add_pdf_ready_to_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddPdfReadyToRegistrants < ActiveRecord::Migration
+class AddPdfReadyToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     add_column "registrants", "pdf_ready", :boolean
   end

--- a/db/migrate/20100429184119_add_barcode_to_registrant.rb
+++ b/db/migrate/20100429184119_add_barcode_to_registrant.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddBarcodeToRegistrant < ActiveRecord::Migration
+class AddBarcodeToRegistrant < ActiveRecord::Migration[4.2]
   def self.up
     add_column "registrants", "barcode", :string, :limit => 12
   end

--- a/db/migrate/20100429230815_add_indexes_to_registrant_stats.rb
+++ b/db/migrate/20100429230815_add_indexes_to_registrant_stats.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddIndexesToRegistrantStats < ActiveRecord::Migration
+class AddIndexesToRegistrantStats < ActiveRecord::Migration[4.2]
   def self.up
     add_index "registrants", "partner_id"
     add_index "registrants", "status"

--- a/db/migrate/20120504183424_add_whitelabeled_to_partners.rb
+++ b/db/migrate/20120504183424_add_whitelabeled_to_partners.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddWhitelabeledToPartners < ActiveRecord::Migration
+class AddWhitelabeledToPartners < ActiveRecord::Migration[4.2]
   def self.up
     add_column :partners, :whitelabeled, :boolean
     add_index :partners, :whitelabeled

--- a/db/migrate/20120526183449_create_email_templates.rb
+++ b/db/migrate/20120526183449_create_email_templates.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class CreateEmailTemplates < ActiveRecord::Migration
+class CreateEmailTemplates < ActiveRecord::Migration[4.2]
   def self.up
     create_table :email_templates do |t|
       t.integer :partner_id, :null => false

--- a/db/migrate/20120527202529_change_registrant_column_defaults.rb
+++ b/db/migrate/20120527202529_change_registrant_column_defaults.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class ChangeRegistrantColumnDefaults < ActiveRecord::Migration
+class ChangeRegistrantColumnDefaults < ActiveRecord::Migration[4.2]
   def self.up
     change_column_default :registrants, :opt_in_email, false
     change_column_default :registrants, :volunteer, false

--- a/db/migrate/20120527203128_add_opt_in_fields_to_partner.rb
+++ b/db/migrate/20120527203128_add_opt_in_fields_to_partner.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddOptInFieldsToPartner < ActiveRecord::Migration
+class AddOptInFieldsToPartner < ActiveRecord::Migration[4.2]
   def self.up
     add_column :partners, :partner_ask_for_volunteers, :boolean, :default=>false
     add_column :partners, :rtv_email_opt_in, :boolean, :default=>true

--- a/db/migrate/20120528023732_add_partner_opt_ins_to_registrant.rb
+++ b/db/migrate/20120528023732_add_partner_opt_ins_to_registrant.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddPartnerOptInsToRegistrant < ActiveRecord::Migration
+class AddPartnerOptInsToRegistrant < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrants, :partner_opt_in_email, :boolean, :default=>false
     add_column :registrants, :partner_opt_in_sms, :boolean, :default=>false

--- a/db/migrate/20120528135437_create_settings_table.rb
+++ b/db/migrate/20120528135437_create_settings_table.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class CreateSettingsTable < ActiveRecord::Migration
+class CreateSettingsTable < ActiveRecord::Migration[4.2]
   def self.up
     create_table :settings, :force => true do |t|
       t.string  :var,         :null => false

--- a/db/migrate/20120529004142_change_partner_defaults.rb
+++ b/db/migrate/20120529004142_change_partner_defaults.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class ChangePartnerDefaults < ActiveRecord::Migration
+class ChangePartnerDefaults < ActiveRecord::Migration[4.2]
   def self.up
     change_column_default :partners, :ask_for_volunteers, true
     change_column_default :partners, :whitelabeled, false

--- a/db/migrate/20120618195258_add_has_state_license_to_registrants.rb
+++ b/db/migrate/20120618195258_add_has_state_license_to_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddHasStateLicenseToRegistrants < ActiveRecord::Migration
+class AddHasStateLicenseToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrants, :has_state_license, :boolean
   end

--- a/db/migrate/20120619224417_add_using_state_online_registration_to_registrants.rb
+++ b/db/migrate/20120619224417_add_using_state_online_registration_to_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddUsingStateOnlineRegistrationToRegistrants < ActiveRecord::Migration
+class AddUsingStateOnlineRegistrationToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrants, :using_state_online_registration, :boolean, :default=>false
   end

--- a/db/migrate/20120621235149_add_javascript_disabled_to_registrants.rb
+++ b/db/migrate/20120621235149_add_javascript_disabled_to_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddJavascriptDisabledToRegistrants < ActiveRecord::Migration
+class AddJavascriptDisabledToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrants, :javascript_disabled, :boolean, :default=>false
   end

--- a/db/migrate/20120721182144_add_api_key_to_partners.rb
+++ b/db/migrate/20120721182144_add_api_key_to_partners.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddApiKeyToPartners < ActiveRecord::Migration
+class AddApiKeyToPartners < ActiveRecord::Migration[4.2]
   def self.up
     add_column :partners, :api_key, :string, :limit=>40, :default=>""
   end

--- a/db/migrate/20120724002725_add_tracking_id_to_registrants.rb
+++ b/db/migrate/20120724002725_add_tracking_id_to_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddTrackingIdToRegistrants < ActiveRecord::Migration
+class AddTrackingIdToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrants, :tracking_id, :string
   end

--- a/db/migrate/20120729173949_add_finish_with_state_to_registrants.rb
+++ b/db/migrate/20120729173949_add_finish_with_state_to_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddFinishWithStateToRegistrants < ActiveRecord::Migration
+class AddFinishWithStateToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrants, :finish_with_state, :boolean, :default=>false
   end

--- a/db/migrate/20120731020636_add_original_survey_questions_to_registrants.rb
+++ b/db/migrate/20120731020636_add_original_survey_questions_to_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddOriginalSurveyQuestionsToRegistrants < ActiveRecord::Migration
+class AddOriginalSurveyQuestionsToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrants, :original_survey_question_1, :string
     add_column :registrants, :original_survey_question_2, :string

--- a/db/migrate/20120802233416_add_privacy_url_to_partners.rb
+++ b/db/migrate/20120802233416_add_privacy_url_to_partners.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddPrivacyUrlToPartners < ActiveRecord::Migration
+class AddPrivacyUrlToPartners < ActiveRecord::Migration[4.2]
   def self.up
     add_column :partners, :privacy_url, :string
   end

--- a/db/migrate/20120809200502_add_send_confirmation_reminder_emails_to_registrants.rb
+++ b/db/migrate/20120809200502_add_send_confirmation_reminder_emails_to_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddSendConfirmationReminderEmailsToRegistrants < ActiveRecord::Migration
+class AddSendConfirmationReminderEmailsToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrants, :send_confirmation_reminder_emails, :boolean, :default=>false
   end

--- a/db/migrate/20120815003450_add_from_email_to_partners.rb
+++ b/db/migrate/20120815003450_add_from_email_to_partners.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddFromEmailToPartners < ActiveRecord::Migration
+class AddFromEmailToPartners < ActiveRecord::Migration[4.2]
   def self.up
     add_column :partners, :from_email, :string
   end

--- a/db/migrate/20120815205556_add_finish_iframe_url_to_partners.rb
+++ b/db/migrate/20120815205556_add_finish_iframe_url_to_partners.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddFinishIframeUrlToPartners < ActiveRecord::Migration
+class AddFinishIframeUrlToPartners < ActiveRecord::Migration[4.2]
   def self.up
     add_column :partners, :finish_iframe_url, :string
   end

--- a/db/migrate/20121004184017_add_building_via_api_call_to_registrants.rb
+++ b/db/migrate/20121004184017_add_building_via_api_call_to_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddBuildingViaApiCallToRegistrants < ActiveRecord::Migration
+class AddBuildingViaApiCallToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrants, :building_via_api_call, :boolean, :default=>false
   end

--- a/db/migrate/20121015175207_add_short_form_to_registrants.rb
+++ b/db/migrate/20121015175207_add_short_form_to_registrants.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddShortFormToRegistrants < ActiveRecord::Migration
+class AddShortFormToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrants, :short_form, :boolean, :default=>false
   end

--- a/db/migrate/20121022185006_add_is_government_partner_to_partners.rb
+++ b/db/migrate/20121022185006_add_is_government_partner_to_partners.rb
@@ -22,7 +22,7 @@
 #                Pivotal Labs, Oregon State University Open Source Lab.
 #
 #***** END LICENSE BLOCK *****
-class AddIsGovernmentPartnerToPartners < ActiveRecord::Migration
+class AddIsGovernmentPartnerToPartners < ActiveRecord::Migration[4.2]
   def self.up
     add_column :partners, :is_government_partner, :boolean, :default=>false
   end

--- a/db/migrate/20121025001914_add_government_partner_state_id_to_partners.rb
+++ b/db/migrate/20121025001914_add_government_partner_state_id_to_partners.rb
@@ -1,4 +1,4 @@
-class AddGovernmentPartnerStateIdToPartners < ActiveRecord::Migration
+class AddGovernmentPartnerStateIdToPartners < ActiveRecord::Migration[4.2]
   def self.up
     add_column :partners, :government_partner_state_id, :integer
   end

--- a/db/migrate/20121025005011_add_government_partner_zip_codes_to_partners.rb
+++ b/db/migrate/20121025005011_add_government_partner_zip_codes_to_partners.rb
@@ -1,4 +1,4 @@
-class AddGovernmentPartnerZipCodesToPartners < ActiveRecord::Migration
+class AddGovernmentPartnerZipCodesToPartners < ActiveRecord::Migration[4.2]
   def self.up
     add_column :partners, :government_partner_zip_codes, :text
   end

--- a/db/migrate/20121027000423_add_csv_ready_to_partners.rb
+++ b/db/migrate/20121027000423_add_csv_ready_to_partners.rb
@@ -1,4 +1,4 @@
-class AddCsvReadyToPartners < ActiveRecord::Migration
+class AddCsvReadyToPartners < ActiveRecord::Migration[4.2]
   def self.up
     add_column :partners, :csv_ready, :boolean, :default=>false
   end

--- a/db/migrate/20121027010132_add_csv_file_name_to_partners.rb
+++ b/db/migrate/20121027010132_add_csv_file_name_to_partners.rb
@@ -1,4 +1,4 @@
-class AddCsvFileNameToPartners < ActiveRecord::Migration
+class AddCsvFileNameToPartners < ActiveRecord::Migration[4.2]
   def self.up
     add_column :partners, :csv_file_name, :string
   end

--- a/db/migrate/20130415030825_add_queue_to_delayed_jobs.rb
+++ b/db/migrate/20130415030825_add_queue_to_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class AddQueueToDelayedJobs < ActiveRecord::Migration
+class AddQueueToDelayedJobs < ActiveRecord::Migration[4.2]
   def self.up
     add_column :delayed_jobs, :queue, :string
   end

--- a/db/migrate/20130516223825_add_online_reg_url_to_geo_states.rb
+++ b/db/migrate/20130516223825_add_online_reg_url_to_geo_states.rb
@@ -1,4 +1,4 @@
-class AddOnlineRegUrlToGeoStates < ActiveRecord::Migration
+class AddOnlineRegUrlToGeoStates < ActiveRecord::Migration[4.2]
   def change
     add_column :geo_states, :online_registration_url, :string
   end

--- a/db/migrate/20130814061038_add_index_on_abandoned_to_registrants.rb
+++ b/db/migrate/20130814061038_add_index_on_abandoned_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddIndexOnAbandonedToRegistrants < ActiveRecord::Migration
+class AddIndexOnAbandonedToRegistrants < ActiveRecord::Migration[4.2]
   def self.up
     add_index :registrants, :abandoned
   end

--- a/db/migrate/20130822180236_add_collect_email_address_to_registrants.rb
+++ b/db/migrate/20130822180236_add_collect_email_address_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddCollectEmailAddressToRegistrants < ActiveRecord::Migration
+class AddCollectEmailAddressToRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :collect_email_address, :string
   end

--- a/db/migrate/20130927204214_add_reg_deadline_to_state_localizations.rb
+++ b/db/migrate/20130927204214_add_reg_deadline_to_state_localizations.rb
@@ -1,4 +1,4 @@
-class AddRegDeadlineToStateLocalizations < ActiveRecord::Migration
+class AddRegDeadlineToStateLocalizations < ActiveRecord::Migration[4.2]
   def change
     add_column :state_localizations, :registration_deadline, :string
   end

--- a/db/migrate/20131210193029_add_general_survey_questions_to_partners.rb
+++ b/db/migrate/20131210193029_add_general_survey_questions_to_partners.rb
@@ -1,4 +1,4 @@
-class AddGeneralSurveyQuestionsToPartners < ActiveRecord::Migration
+class AddGeneralSurveyQuestionsToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :survey_question_1, :text
     add_column :partners, :survey_question_2, :text

--- a/db/migrate/20140123130350_change_locale_column_limit.rb
+++ b/db/migrate/20140123130350_change_locale_column_limit.rb
@@ -1,4 +1,4 @@
-class ChangeLocaleColumnLimit < ActiveRecord::Migration
+class ChangeLocaleColumnLimit < ActiveRecord::Migration[4.2]
   def up
     change_column :registrants, :locale, :string, :limit => 64
   end

--- a/db/migrate/20140123131546_change_locale_column_limit_for_state_localizations.rb
+++ b/db/migrate/20140123131546_change_locale_column_limit_for_state_localizations.rb
@@ -1,4 +1,4 @@
-class ChangeLocaleColumnLimitForStateLocalizations < ActiveRecord::Migration
+class ChangeLocaleColumnLimitForStateLocalizations < ActiveRecord::Migration[4.2]
   def up
     change_column :state_localizations, :locale, :string, :limit => 64
   end

--- a/db/migrate/20140124151534_add_pdf_instructions_to_state_localizations.rb
+++ b/db/migrate/20140124151534_add_pdf_instructions_to_state_localizations.rb
@@ -1,4 +1,4 @@
-class AddPdfInstructionsToStateLocalizations < ActiveRecord::Migration
+class AddPdfInstructionsToStateLocalizations < ActiveRecord::Migration[4.2]
   def change
     add_column :state_localizations, :pdf_instructions, :string
   end

--- a/db/migrate/20140124153314_add_email_instructions_to_state_localizations.rb
+++ b/db/migrate/20140124153314_add_email_instructions_to_state_localizations.rb
@@ -1,4 +1,4 @@
-class AddEmailInstructionsToStateLocalizations < ActiveRecord::Migration
+class AddEmailInstructionsToStateLocalizations < ActiveRecord::Migration[4.2]
   def change
     add_column :state_localizations, :email_instructions, :string
   end

--- a/db/migrate/20140124174157_change_state_localizations_to_texts.rb
+++ b/db/migrate/20140124174157_change_state_localizations_to_texts.rb
@@ -1,4 +1,4 @@
-class ChangeStateLocalizationsToTexts < ActiveRecord::Migration
+class ChangeStateLocalizationsToTexts < ActiveRecord::Migration[4.2]
   def up
     change_column :state_localizations, :parties,  :string, :limit => 1024
     change_column :state_localizations, :sub_18,  :string, :limit => 1024

--- a/db/migrate/20140124185632_add_will_be_18_by_election_to_registrants.rb
+++ b/db/migrate/20140124185632_add_will_be_18_by_election_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddWillBe18ByElectionToRegistrants < ActiveRecord::Migration
+class AddWillBe18ByElectionToRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :will_be_18_by_election, :boolean
   end

--- a/db/migrate/20140125001349_add_redirect_to_online_registration_url_to_geo_states.rb
+++ b/db/migrate/20140125001349_add_redirect_to_online_registration_url_to_geo_states.rb
@@ -1,4 +1,4 @@
-class AddRedirectToOnlineRegistrationUrlToGeoStates < ActiveRecord::Migration
+class AddRedirectToOnlineRegistrationUrlToGeoStates < ActiveRecord::Migration[4.2]
   def change
     add_column :geo_states, :redirect_to_online_registration_url, :boolean
   end

--- a/db/migrate/20140312013806_add_state_ovr_data_to_registrants.rb
+++ b/db/migrate/20140312013806_add_state_ovr_data_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddStateOvrDataToRegistrants < ActiveRecord::Migration
+class AddStateOvrDataToRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :state_ovr_data, :text
   end

--- a/db/migrate/20140404165046_remove_redirect_to_online_registration_url_from_geo_states.rb
+++ b/db/migrate/20140404165046_remove_redirect_to_online_registration_url_from_geo_states.rb
@@ -1,4 +1,4 @@
-class RemoveRedirectToOnlineRegistrationUrlFromGeoStates < ActiveRecord::Migration
+class RemoveRedirectToOnlineRegistrationUrlFromGeoStates < ActiveRecord::Migration[4.2]
   def up
     remove_column :geo_states, :redirect_to_online_registration_url
   end

--- a/db/migrate/20140528193930_add_external_tracking_snippet_to_partners.rb
+++ b/db/migrate/20140528193930_add_external_tracking_snippet_to_partners.rb
@@ -1,4 +1,4 @@
-class AddExternalTrackingSnippetToPartners < ActiveRecord::Migration
+class AddExternalTrackingSnippetToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :external_tracking_snippet, :text
   end

--- a/db/migrate/20140613132702_create_zip_code_county_addresses.rb
+++ b/db/migrate/20140613132702_create_zip_code_county_addresses.rb
@@ -1,4 +1,4 @@
-class CreateZipCodeCountyAddresses < ActiveRecord::Migration
+class CreateZipCodeCountyAddresses < ActiveRecord::Migration[4.2]
   def change
     create_table :zip_code_county_addresses do |t|
       t.integer :geo_state_id

--- a/db/migrate/20140703145450_add_registration_instructions_url_to_partners.rb
+++ b/db/migrate/20140703145450_add_registration_instructions_url_to_partners.rb
@@ -1,4 +1,4 @@
-class AddRegistrationInstructionsUrlToPartners < ActiveRecord::Migration
+class AddRegistrationInstructionsUrlToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :registration_instructions_url, :string
   end

--- a/db/migrate/20140727152509_change_parter_ask_for_volunteers_default_to_false.rb
+++ b/db/migrate/20140727152509_change_parter_ask_for_volunteers_default_to_false.rb
@@ -1,4 +1,4 @@
-class ChangeParterAskForVolunteersDefaultToFalse < ActiveRecord::Migration
+class ChangeParterAskForVolunteersDefaultToFalse < ActiveRecord::Migration[4.2]
   def up
     change_column_default :partners, :ask_for_volunteers, false
   end

--- a/db/migrate/20141024195843_add_remote_partner_id_to_registrants.rb
+++ b/db/migrate/20141024195843_add_remote_partner_id_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddRemotePartnerIdToRegistrants < ActiveRecord::Migration
+class AddRemotePartnerIdToRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :remote_partner_id, :integer
     add_index :registrants, :remote_partner_id

--- a/db/migrate/20141109005035_add_reg_abandoned_index.rb
+++ b/db/migrate/20141109005035_add_reg_abandoned_index.rb
@@ -1,4 +1,4 @@
-class AddRegAbandonedIndex < ActiveRecord::Migration
+class AddRegAbandonedIndex < ActiveRecord::Migration[4.2]
   def up
     add_index :registrants, [:abandoned, :status], :name=>:registrant_stale 
   end

--- a/db/migrate/20141109005125_add_index_for_reminders.rb
+++ b/db/migrate/20141109005125_add_index_for_reminders.rb
@@ -1,4 +1,4 @@
-class AddIndexForReminders < ActiveRecord::Migration
+class AddIndexForReminders < ActiveRecord::Migration[4.2]
   def up
     add_index :registrants, [:reminders_left, :updated_at]
   end

--- a/db/migrate/20141109005207_create_pdf_generations.rb
+++ b/db/migrate/20141109005207_create_pdf_generations.rb
@@ -1,4 +1,4 @@
-class CreatePdfGenerations < ActiveRecord::Migration
+class CreatePdfGenerations < ActiveRecord::Migration[4.2]
   def change
     create_table :pdf_generations do |t|
       t.integer :registrant_id

--- a/db/migrate/20141110211317_add_remote_uid_to_registrants.rb
+++ b/db/migrate/20141110211317_add_remote_uid_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddRemoteUidToRegistrants < ActiveRecord::Migration
+class AddRemoteUidToRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :remote_uid, :string
     add_index :registrants, :remote_uid

--- a/db/migrate/20141110212955_add_remote_pdf_path_to_registrants.rb
+++ b/db/migrate/20141110212955_add_remote_pdf_path_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddRemotePdfPathToRegistrants < ActiveRecord::Migration
+class AddRemotePdfPathToRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :remote_pdf_path, :string
   end

--- a/db/migrate/20141114165714_add_custom_stop_reminders_url_to_registrants.rb
+++ b/db/migrate/20141114165714_add_custom_stop_reminders_url_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddCustomStopRemindersUrlToRegistrants < ActiveRecord::Migration
+class AddCustomStopRemindersUrlToRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :custom_stop_reminders_url, :string
   end

--- a/db/migrate/20141206195748_create_priority_pdf_generations.rb
+++ b/db/migrate/20141206195748_create_priority_pdf_generations.rb
@@ -1,4 +1,4 @@
-class CreatePriorityPdfGenerations < ActiveRecord::Migration
+class CreatePriorityPdfGenerations < ActiveRecord::Migration[4.2]
   def change
     create_table :priority_pdf_generations do |t|
       t.integer :registrant_id

--- a/db/migrate/20150609201015_add_subject_to_email_templates.rb
+++ b/db/migrate/20150609201015_add_subject_to_email_templates.rb
@@ -1,4 +1,4 @@
-class AddSubjectToEmailTemplates < ActiveRecord::Migration
+class AddSubjectToEmailTemplates < ActiveRecord::Migration[4.2]
   def change
     add_column :email_templates, :subject, :string
   end

--- a/db/migrate/20150621025719_add_pdf_downloaded_to_registrants.rb
+++ b/db/migrate/20150621025719_add_pdf_downloaded_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddPdfDownloadedToRegistrants < ActiveRecord::Migration
+class AddPdfDownloadedToRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :pdf_downloaded, :boolean, :default=>false
   end

--- a/db/migrate/20150621034509_add_pdf_downloaded_at_to_registrants.rb
+++ b/db/migrate/20150621034509_add_pdf_downloaded_at_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddPdfDownloadedAtToRegistrants < ActiveRecord::Migration
+class AddPdfDownloadedAtToRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :pdf_downloaded_at, :datetime
   end

--- a/db/migrate/20150702212836_add_final_reminder_delivered_to_registrants.rb
+++ b/db/migrate/20150702212836_add_final_reminder_delivered_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddFinalReminderDeliveredToRegistrants < ActiveRecord::Migration
+class AddFinalReminderDeliveredToRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :final_reminder_delivered, :boolean, :default=>false
     # default is false, but need to set all prior registrants to delivered

--- a/db/migrate/20150708214737_add_pixel_tracking_codes_to_partners.rb
+++ b/db/migrate/20150708214737_add_pixel_tracking_codes_to_partners.rb
@@ -1,4 +1,4 @@
-class AddPixelTrackingCodesToPartners < ActiveRecord::Migration
+class AddPixelTrackingCodesToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :pixel_tracking_codes, :text
   end

--- a/db/migrate/20151008153652_add_index_to_registrants_finish_with_state.rb
+++ b/db/migrate/20151008153652_add_index_to_registrants_finish_with_state.rb
@@ -1,4 +1,4 @@
-class AddIndexToRegistrantsFinishWithState < ActiveRecord::Migration
+class AddIndexToRegistrantsFinishWithState < ActiveRecord::Migration[4.2]
   def change
     add_index :registrants, [:finish_with_state, :partner_id, :status, :created_at], name: :index_registrants_for_stats
   end

--- a/db/migrate/20151008160637_index_registrants_for_more_partner_stats.rb
+++ b/db/migrate/20151008160637_index_registrants_for_more_partner_stats.rb
@@ -1,4 +1,4 @@
-class IndexRegistrantsForMorePartnerStats < ActiveRecord::Migration
+class IndexRegistrantsForMorePartnerStats < ActiveRecord::Migration[4.2]
   def change
     add_index :registrants, [:finish_with_state, :partner_id, :status], name: :index_registrants_for_started_count
     add_index :registrants, [:finish_with_state, :partner_id, :status, :home_state_id], name: :index_registrants_by_state

--- a/db/migrate/20151008162650_add_index_to_registrations_on_partner_and_status.rb
+++ b/db/migrate/20151008162650_add_index_to_registrations_on_partner_and_status.rb
@@ -1,4 +1,4 @@
-class AddIndexToRegistrationsOnPartnerAndStatus < ActiveRecord::Migration
+class AddIndexToRegistrationsOnPartnerAndStatus < ActiveRecord::Migration[4.2]
   def change
     add_index :registrants, [:partner_id, :status], name: :index_registrants_by_partner_and_status    
   end

--- a/db/migrate/20160205162852_change_zip_code_county_to_array.rb
+++ b/db/migrate/20160205162852_change_zip_code_county_to_array.rb
@@ -1,4 +1,4 @@
-class ChangeZipCodeCountyToArray < ActiveRecord::Migration
+class ChangeZipCodeCountyToArray < ActiveRecord::Migration[4.2]
   def up
     change_column :zip_code_county_addresses, :county, :text
   end

--- a/db/migrate/20160205170602_add_good_bad_cities_to_zip_code_county_table.rb
+++ b/db/migrate/20160205170602_add_good_bad_cities_to_zip_code_county_table.rb
@@ -1,4 +1,4 @@
-class AddGoodBadCitiesToZipCodeCountyTable < ActiveRecord::Migration
+class AddGoodBadCitiesToZipCodeCountyTable < ActiveRecord::Migration[4.2]
   def change
     add_column :zip_code_county_addresses, :cities, :text
     add_column :zip_code_county_addresses, :unacceptable_cities, :text

--- a/db/migrate/20160205225341_add_last_checked_to_zip_code_county_address.rb
+++ b/db/migrate/20160205225341_add_last_checked_to_zip_code_county_address.rb
@@ -1,4 +1,4 @@
-class AddLastCheckedToZipCodeCountyAddress < ActiveRecord::Migration
+class AddLastCheckedToZipCodeCountyAddress < ActiveRecord::Migration[4.2]
   def change
     add_column :zip_code_county_addresses, :last_checked, :datetime
   end

--- a/db/migrate/20160616123607_add_from_email_verified_at_to_partner.rb
+++ b/db/migrate/20160616123607_add_from_email_verified_at_to_partner.rb
@@ -1,4 +1,4 @@
-class AddFromEmailVerifiedAtToPartner < ActiveRecord::Migration
+class AddFromEmailVerifiedAtToPartner < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :from_email_verified_at, :datetime
     add_column :partners, :from_email_verification_checked_at, :datetime

--- a/db/migrate/20160718121459_add_is_fake_to_registrant.rb
+++ b/db/migrate/20160718121459_add_is_fake_to_registrant.rb
@@ -1,4 +1,4 @@
-class AddIsFakeToRegistrant < ActiveRecord::Migration
+class AddIsFakeToRegistrant < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :is_fake, :boolean, default: false
   end

--- a/db/migrate/20160819095327_add_has_ssn_to_registrants.rb
+++ b/db/migrate/20160819095327_add_has_ssn_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddHasSsnToRegistrants < ActiveRecord::Migration
+class AddHasSsnToRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :has_ssn, :boolean
   end

--- a/db/migrate/20160819100534_add_counties_to_addresses.rb
+++ b/db/migrate/20160819100534_add_counties_to_addresses.rb
@@ -1,4 +1,4 @@
-class AddCountiesToAddresses < ActiveRecord::Migration
+class AddCountiesToAddresses < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :home_county, :string
     add_column :registrants, :prev_county, :string

--- a/db/migrate/20160825143125_add_open_tracking_id_to_registrants.rb
+++ b/db/migrate/20160825143125_add_open_tracking_id_to_registrants.rb
@@ -1,4 +1,4 @@
-class AddOpenTrackingIdToRegistrants < ActiveRecord::Migration
+class AddOpenTrackingIdToRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :registrants, :open_tracking_id, :string
   end

--- a/db/migrate/20160827171640_add_pdf_other_instructions_to_state_localizations.rb
+++ b/db/migrate/20160827171640_add_pdf_other_instructions_to_state_localizations.rb
@@ -1,4 +1,4 @@
-class AddPdfOtherInstructionsToStateLocalizations < ActiveRecord::Migration
+class AddPdfOtherInstructionsToStateLocalizations < ActiveRecord::Migration[4.2]
   def change
     add_column :state_localizations, :pdf_other_instructions, :string, :limit => 1024
   end

--- a/db/migrate/20160902083730_add_approval_request_to_partners.rb
+++ b/db/migrate/20160902083730_add_approval_request_to_partners.rb
@@ -1,4 +1,4 @@
-class AddApprovalRequestToPartners < ActiveRecord::Migration
+class AddApprovalRequestToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :branding_update_request, :text
   end

--- a/db/migrate/20160906192704_add_enabled_for_grommet_to_partners.rb
+++ b/db/migrate/20160906192704_add_enabled_for_grommet_to_partners.rb
@@ -1,4 +1,4 @@
-class AddEnabledForGrommetToPartners < ActiveRecord::Migration
+class AddEnabledForGrommetToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :enabled_for_grommet, :boolean, null: false, default: false
   end

--- a/db/migrate/20160909093241_create_admins.rb
+++ b/db/migrate/20160909093241_create_admins.rb
@@ -1,4 +1,4 @@
-class CreateAdmins < ActiveRecord::Migration
+class CreateAdmins < ActiveRecord::Migration[4.2]
   def change
     create_table :admins do |t|
       t.string :username

--- a/db/migrate/20160915074811_add_active_to_partners.rb
+++ b/db/migrate/20160915074811_add_active_to_partners.rb
@@ -1,4 +1,4 @@
-class AddActiveToPartners < ActiveRecord::Migration
+class AddActiveToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :active, :boolean, default: true, null: false
   end

--- a/db/migrate/20160923220232_create_grommet_requests.rb
+++ b/db/migrate/20160923220232_create_grommet_requests.rb
@@ -1,4 +1,4 @@
-class CreateGrommetRequests < ActiveRecord::Migration
+class CreateGrommetRequests < ActiveRecord::Migration[4.2]
   def change
     create_table :grommet_requests do |t|
 

--- a/db/migrate/20161213141536_add_external_conversion_snippet_to_partners.rb
+++ b/db/migrate/20161213141536_add_external_conversion_snippet_to_partners.rb
@@ -1,4 +1,4 @@
-class AddExternalConversionSnippetToPartners < ActiveRecord::Migration
+class AddExternalConversionSnippetToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :external_conversion_snippet, :text
   end

--- a/db/migrate/20161213164552_add_replace_system_css_to_partners.rb
+++ b/db/migrate/20161213164552_add_replace_system_css_to_partners.rb
@@ -1,4 +1,4 @@
-class AddReplaceSystemCssToPartners < ActiveRecord::Migration
+class AddReplaceSystemCssToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :replace_system_css, :text
   end

--- a/db/migrate/20170719153519_create_tracking_events.rb
+++ b/db/migrate/20170719153519_create_tracking_events.rb
@@ -1,4 +1,4 @@
-class CreateTrackingEvents < ActiveRecord::Migration
+class CreateTrackingEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :tracking_events do |t|
       t.string :tracking_event_name

--- a/db/migrate/20171016204650_create_state_registrants_pa_registrants.rb
+++ b/db/migrate/20171016204650_create_state_registrants_pa_registrants.rb
@@ -1,4 +1,4 @@
-class CreateStateRegistrantsPaRegistrants < ActiveRecord::Migration
+class CreateStateRegistrantsPaRegistrants < ActiveRecord::Migration[4.2]
   def change
     create_table :state_registrants_pa_registrants do |t|
       t.string :email

--- a/db/migrate/20171024184426_add_registrant_id_to_pa_registrants.rb
+++ b/db/migrate/20171024184426_add_registrant_id_to_pa_registrants.rb
@@ -1,4 +1,4 @@
-class AddRegistrantIdToPaRegistrants < ActiveRecord::Migration
+class AddRegistrantIdToPaRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_pa_registrants, :registrant_id, :string, index: true
   end

--- a/db/migrate/20171024185050_add_locale_to_state_registrants_pa_registrants.rb
+++ b/db/migrate/20171024185050_add_locale_to_state_registrants_pa_registrants.rb
@@ -1,4 +1,4 @@
-class AddLocaleToStateRegistrantsPaRegistrants < ActiveRecord::Migration
+class AddLocaleToStateRegistrantsPaRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_pa_registrants, :locale, :string
   end

--- a/db/migrate/20171024192240_add_status_to_state_registrants_pa_registrants.rb
+++ b/db/migrate/20171024192240_add_status_to_state_registrants_pa_registrants.rb
@@ -1,4 +1,4 @@
-class AddStatusToStateRegistrantsPaRegistrants < ActiveRecord::Migration
+class AddStatusToStateRegistrantsPaRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_pa_registrants, :status, :string
   end

--- a/db/migrate/20171025215129_add_confirm_no_penndot_number_to_state_registrants_pa_registrant.rb
+++ b/db/migrate/20171025215129_add_confirm_no_penndot_number_to_state_registrants_pa_registrant.rb
@@ -1,4 +1,4 @@
-class AddConfirmNoPenndotNumberToStateRegistrantsPaRegistrant < ActiveRecord::Migration
+class AddConfirmNoPenndotNumberToStateRegistrantsPaRegistrant < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_pa_registrants, :confirm_no_penndot_number, :boolean
   end

--- a/db/migrate/20171025225021_add_transaction_info_to_pa_registrants.rb
+++ b/db/migrate/20171025225021_add_transaction_info_to_pa_registrants.rb
@@ -1,4 +1,4 @@
-class AddTransactionInfoToPaRegistrants < ActiveRecord::Migration
+class AddTransactionInfoToPaRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_pa_registrants, :pa_submission_complete, :boolean
     add_column :state_registrants_pa_registrants, :pa_transaction_id, :string

--- a/db/migrate/20171026210116_fix_prev_suffix_to_middle.rb
+++ b/db/migrate/20171026210116_fix_prev_suffix_to_middle.rb
@@ -1,4 +1,4 @@
-class FixPrevSuffixToMiddle < ActiveRecord::Migration
+class FixPrevSuffixToMiddle < ActiveRecord::Migration[4.2]
   def up
     add_column :state_registrants_pa_registrants, :previous_middle_name, :string
     remove_column :state_registrants_pa_registrants, :previous_suffix

--- a/db/migrate/20171204133005_create_registrant_statuses.rb
+++ b/db/migrate/20171204133005_create_registrant_statuses.rb
@@ -1,4 +1,4 @@
-class CreateRegistrantStatuses < ActiveRecord::Migration
+class CreateRegistrantStatuses < ActiveRecord::Migration[4.2]
   def change
     create_table :registrant_statuses do |t|
       t.belongs_to :registrant

--- a/db/migrate/20171205131346_add_tracking_event_indexes.rb
+++ b/db/migrate/20171205131346_add_tracking_event_indexes.rb
@@ -1,4 +1,4 @@
-class AddTrackingEventIndexes < ActiveRecord::Migration
+class AddTrackingEventIndexes < ActiveRecord::Migration[4.2]
   def change
     add_index :tracking_events, :source_tracking_id
     add_index :tracking_events, :partner_tracking_id

--- a/db/migrate/20171221225913_create_state_registrants_va_registrants.rb
+++ b/db/migrate/20171221225913_create_state_registrants_va_registrants.rb
@@ -1,4 +1,4 @@
-class CreateStateRegistrantsVaRegistrants < ActiveRecord::Migration
+class CreateStateRegistrantsVaRegistrants < ActiveRecord::Migration[4.2]
   def change
     create_table :state_registrants_va_registrants do |t|
       t.boolean :confirm_voter_record_update

--- a/db/migrate/20180116190707_add_has_mailing_address_and_confirm_register_to_vote_to_state_registrants_va_registrants.rb
+++ b/db/migrate/20180116190707_add_has_mailing_address_and_confirm_register_to_vote_to_state_registrants_va_registrants.rb
@@ -1,4 +1,4 @@
-class AddHasMailingAddressAndConfirmRegisterToVoteToStateRegistrantsVaRegistrants < ActiveRecord::Migration
+class AddHasMailingAddressAndConfirmRegisterToVoteToStateRegistrantsVaRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_va_registrants, :has_mailing_address, :boolean
     add_column :state_registrants_va_registrants, :confirm_register_to_vote, :boolean

--- a/db/migrate/20180116191735_add_phone_type_to_state_registrants_va_registrants.rb
+++ b/db/migrate/20180116191735_add_phone_type_to_state_registrants_va_registrants.rb
@@ -1,4 +1,4 @@
-class AddPhoneTypeToStateRegistrantsVaRegistrants < ActiveRecord::Migration
+class AddPhoneTypeToStateRegistrantsVaRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_va_registrants, :phone_type, :string
   end

--- a/db/migrate/20180116192425_add_phone_type_to_state_registrants_pa_registrants.rb
+++ b/db/migrate/20180116192425_add_phone_type_to_state_registrants_pa_registrants.rb
@@ -1,4 +1,4 @@
-class AddPhoneTypeToStateRegistrantsPaRegistrants < ActiveRecord::Migration
+class AddPhoneTypeToStateRegistrantsPaRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_pa_registrants, :phone_type, :string
   end

--- a/db/migrate/20180601193926_change_pa_registrant_signature_to_text.rb
+++ b/db/migrate/20180601193926_change_pa_registrant_signature_to_text.rb
@@ -1,4 +1,4 @@
-class ChangePaRegistrantSignatureToText < ActiveRecord::Migration
+class ChangePaRegistrantSignatureToText < ActiveRecord::Migration[4.2]
   def up
     change_column :state_registrants_pa_registrants, :voter_signature_image, :text    
   end

--- a/db/migrate/20180601202559_add_signature_method_to_pa_registrant.rb
+++ b/db/migrate/20180601202559_add_signature_method_to_pa_registrant.rb
@@ -1,4 +1,4 @@
-class AddSignatureMethodToPaRegistrant < ActiveRecord::Migration
+class AddSignatureMethodToPaRegistrant < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_pa_registrants, :signature_method, :string
   end

--- a/db/migrate/20180710204718_add_continue_on_device_methods_to_pa_registrants.rb
+++ b/db/migrate/20180710204718_add_continue_on_device_methods_to_pa_registrants.rb
@@ -1,4 +1,4 @@
-class AddContinueOnDeviceMethodsToPaRegistrants < ActiveRecord::Migration
+class AddContinueOnDeviceMethodsToPaRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_pa_registrants, :sms_number_for_continue_on_device, :string
     add_column :state_registrants_pa_registrants, :email_address_for_continue_on_device, :string

--- a/db/migrate/20180710231408_add_pa_api_key_to_partners.rb
+++ b/db/migrate/20180710231408_add_pa_api_key_to_partners.rb
@@ -1,4 +1,4 @@
-class AddPaApiKeyToPartners < ActiveRecord::Migration
+class AddPaApiKeyToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :pa_api_key, :string
   end

--- a/db/migrate/20180711112720_remove_limit_from_pa_signature.rb
+++ b/db/migrate/20180711112720_remove_limit_from_pa_signature.rb
@@ -1,4 +1,4 @@
-class RemoveLimitFromPaSignature < ActiveRecord::Migration
+class RemoveLimitFromPaSignature < ActiveRecord::Migration[4.2]
   def up
     change_column :state_registrants_pa_registrants, :voter_signature_image, :text, :limit => nil
   end

--- a/db/migrate/20180716180136_add_failed_login_count_to_partners.rb
+++ b/db/migrate/20180716180136_add_failed_login_count_to_partners.rb
@@ -1,4 +1,4 @@
-class AddFailedLoginCountToPartners < ActiveRecord::Migration
+class AddFailedLoginCountToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :failed_login_count, :integer
   end

--- a/db/migrate/20180716180222_add_failed_login_count_to_admins.rb
+++ b/db/migrate/20180716180222_add_failed_login_count_to_admins.rb
@@ -1,4 +1,4 @@
-class AddFailedLoginCountToAdmins < ActiveRecord::Migration
+class AddFailedLoginCountToAdmins < ActiveRecord::Migration[4.2]
   def change
     add_column :admins, :failed_login_count, :integer
   end

--- a/db/migrate/20180716180845_add_authlogic_columns_to_partners_admins.rb
+++ b/db/migrate/20180716180845_add_authlogic_columns_to_partners_admins.rb
@@ -1,4 +1,4 @@
-class AddAuthlogicColumnsToPartnersAdmins < ActiveRecord::Migration
+class AddAuthlogicColumnsToPartnersAdmins < ActiveRecord::Migration[4.2]
   def change
     add_index :admins, :persistence_token, unique: true
 

--- a/db/migrate/20180718122833_add_original_partner_id_to_state_registrants_pa_registrants.rb
+++ b/db/migrate/20180718122833_add_original_partner_id_to_state_registrants_pa_registrants.rb
@@ -1,4 +1,4 @@
-class AddOriginalPartnerIdToStateRegistrantsPaRegistrants < ActiveRecord::Migration
+class AddOriginalPartnerIdToStateRegistrantsPaRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_pa_registrants, :original_partner_id, :integer
     add_index :state_registrants_pa_registrants, :original_partner_id, name: :pa_registrants_original_partner_id

--- a/db/migrate/20180724102556_add_request_hash_to_grommet_requests.rb
+++ b/db/migrate/20180724102556_add_request_hash_to_grommet_requests.rb
@@ -1,4 +1,4 @@
-class AddRequestHashToGrommetRequests < ActiveRecord::Migration
+class AddRequestHashToGrommetRequests < ActiveRecord::Migration[4.2]
   def change
     add_column :grommet_requests, :request_hash, :string
     add_index  :grommet_requests, :request_hash

--- a/db/migrate/20180804210818_add_grommet_csv_ready_to_partners.rb
+++ b/db/migrate/20180804210818_add_grommet_csv_ready_to_partners.rb
@@ -1,4 +1,4 @@
-class AddGrommetCsvReadyToPartners < ActiveRecord::Migration
+class AddGrommetCsvReadyToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :grommet_csv_ready, :boolean
     add_column :partners, :grommet_csv_file_name, :string

--- a/db/migrate/20180808021143_add_partner_opt_ins_to_state_registrants_pa_registrants.rb
+++ b/db/migrate/20180808021143_add_partner_opt_ins_to_state_registrants_pa_registrants.rb
@@ -1,4 +1,4 @@
-class AddPartnerOptInsToStateRegistrantsPaRegistrants < ActiveRecord::Migration
+class AddPartnerOptInsToStateRegistrantsPaRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_pa_registrants, :partner_opt_in_sms, :boolean
     add_column :state_registrants_pa_registrants, :partner_opt_in_email, :boolean

--- a/db/migrate/20180820202202_add_penndot_retries_to_state_registrants_pa_registrants.rb
+++ b/db/migrate/20180820202202_add_penndot_retries_to_state_registrants_pa_registrants.rb
@@ -1,4 +1,4 @@
-class AddPenndotRetriesToStateRegistrantsPaRegistrants < ActiveRecord::Migration
+class AddPenndotRetriesToStateRegistrantsPaRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_pa_registrants, :penndot_retries, :integer, default: 0
   end

--- a/db/migrate/20180827214401_add_request_headers_to_grommet_requests.rb
+++ b/db/migrate/20180827214401_add_request_headers_to_grommet_requests.rb
@@ -1,4 +1,4 @@
-class AddRequestHeadersToGrommetRequests < ActiveRecord::Migration
+class AddRequestHeadersToGrommetRequests < ActiveRecord::Migration[4.2]
   def change
     add_column :grommet_requests, :request_headers, :text
   end

--- a/db/migrate/20180910170029_change_dj_limits.rb
+++ b/db/migrate/20180910170029_change_dj_limits.rb
@@ -1,4 +1,4 @@
-class ChangeDjLimits < ActiveRecord::Migration
+class ChangeDjLimits < ActiveRecord::Migration[4.2]
   def change
     change_column :delayed_jobs, :handler, :text, limit: 16.megabytes - 1
     change_column :delayed_jobs, :last_error, :text, limit: 16.megabytes - 1    

--- a/db/migrate/20180914110348_create_pdf_deliveries.rb
+++ b/db/migrate/20180914110348_create_pdf_deliveries.rb
@@ -1,4 +1,4 @@
-class CreatePdfDeliveries < ActiveRecord::Migration
+class CreatePdfDeliveries < ActiveRecord::Migration[4.2]
   def change
     create_table :pdf_deliveries do |t|
       t.integer :registrant_id

--- a/db/migrate/20180925153459_update_localization_lengths.rb
+++ b/db/migrate/20180925153459_update_localization_lengths.rb
@@ -1,4 +1,4 @@
-class UpdateLocalizationLengths < ActiveRecord::Migration
+class UpdateLocalizationLengths < ActiveRecord::Migration[4.2]
   def change
     
     change_column :state_localizations, :parties, :text,                   limit: 20480

--- a/db/migrate/20181015155717_add_opt_ins_to_va.rb
+++ b/db/migrate/20181015155717_add_opt_ins_to_va.rb
@@ -1,4 +1,4 @@
-class AddOptInsToVa < ActiveRecord::Migration
+class AddOptInsToVa < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_va_registrants, :partner_opt_in_sms, :boolean
     add_column :state_registrants_va_registrants, :partner_opt_in_email, :boolean

--- a/db/migrate/20181127114114_create_ses_notifications.rb
+++ b/db/migrate/20181127114114_create_ses_notifications.rb
@@ -1,4 +1,4 @@
-class CreateSesNotifications < ActiveRecord::Migration
+class CreateSesNotifications < ActiveRecord::Migration[4.2]
   def change
     create_table :ses_notifications do |t|
       t.text :request_params

--- a/db/migrate/20181127115859_create_email_addresses.rb
+++ b/db/migrate/20181127115859_create_email_addresses.rb
@@ -1,4 +1,4 @@
-class CreateEmailAddresses < ActiveRecord::Migration
+class CreateEmailAddresses < ActiveRecord::Migration[4.2]
   def change
     create_table :email_addresses do |t|
       t.string :email_address

--- a/db/migrate/20190125201539_add_online_registration_system_name_to_geo_states.rb
+++ b/db/migrate/20190125201539_add_online_registration_system_name_to_geo_states.rb
@@ -1,4 +1,4 @@
-class AddOnlineRegistrationSystemNameToGeoStates < ActiveRecord::Migration
+class AddOnlineRegistrationSystemNameToGeoStates < ActiveRecord::Migration[4.2]
   def change
     add_column :geo_states, :online_registration_system_name, :string
   end

--- a/db/migrate/20190329144200_add_active_to_admins.rb
+++ b/db/migrate/20190329144200_add_active_to_admins.rb
@@ -1,4 +1,4 @@
-class AddActiveToAdmins < ActiveRecord::Migration
+class AddActiveToAdmins < ActiveRecord::Migration[4.2]
   def change
     add_column :admins, :active,  :boolean, default: true, null: false
   end

--- a/db/migrate/20190419174516_create_email_domains.rb
+++ b/db/migrate/20190419174516_create_email_domains.rb
@@ -1,4 +1,4 @@
-class CreateEmailDomains < ActiveRecord::Migration
+class CreateEmailDomains < ActiveRecord::Migration[4.2]
   def change
     create_table :email_domains do |t|
       t.string :domain

--- a/db/migrate/20190522163543_create_ab_tests.rb
+++ b/db/migrate/20190522163543_create_ab_tests.rb
@@ -1,4 +1,4 @@
-class CreateAbTests < ActiveRecord::Migration
+class CreateAbTests < ActiveRecord::Migration[4.2]
   def change
     unless ActiveRecord::Base.connection.table_exists? 'ab_tests'
       create_table :ab_tests do |t|

--- a/db/migrate/20190815171832_create_reports.rb
+++ b/db/migrate/20190815171832_create_reports.rb
@@ -1,4 +1,4 @@
-class CreateReports < ActiveRecord::Migration
+class CreateReports < ActiveRecord::Migration[4.2]
   def change
     create_table :reports do |t|
       t.datetime :start_date

--- a/db/migrate/20190815175801_add_data_to_reports.rb
+++ b/db/migrate/20190815175801_add_data_to_reports.rb
@@ -1,4 +1,4 @@
-class AddDataToReports < ActiveRecord::Migration
+class AddDataToReports < ActiveRecord::Migration[4.2]
   def change
     add_column :reports, :data, :text
   end

--- a/db/migrate/20190828214835_create_report_data.rb
+++ b/db/migrate/20190828214835_create_report_data.rb
@@ -1,4 +1,4 @@
-class CreateReportData < ActiveRecord::Migration
+class CreateReportData < ActiveRecord::Migration[4.2]
   def change
     create_table :report_data do |t|
       t.integer :report_id

--- a/db/migrate/20190829013202_add_hash_to_report_data.rb
+++ b/db/migrate/20190829013202_add_hash_to_report_data.rb
@@ -1,4 +1,4 @@
-class AddHashToReportData < ActiveRecord::Migration
+class AddHashToReportData < ActiveRecord::Migration[4.2]
   def change
     add_column :report_data, :h_value, :text
   end

--- a/db/migrate/20190830180324_update_report_data_column.rb
+++ b/db/migrate/20190830180324_update_report_data_column.rb
@@ -1,4 +1,4 @@
-class UpdateReportDataColumn < ActiveRecord::Migration
+class UpdateReportDataColumn < ActiveRecord::Migration[4.2]
   def change
     rename_column :reports, :data, :filters
   end

--- a/db/migrate/20190830235131_add_error_to_reports.rb
+++ b/db/migrate/20190830235131_add_error_to_reports.rb
@@ -1,4 +1,4 @@
-class AddErrorToReports < ActiveRecord::Migration
+class AddErrorToReports < ActiveRecord::Migration[4.2]
   def change
     add_column :reports, :error, :text
   end

--- a/db/migrate/20191101150558_add_partner_sms_fields_and_reset.rb
+++ b/db/migrate/20191101150558_add_partner_sms_fields_and_reset.rb
@@ -1,4 +1,4 @@
-class AddPartnerSmsFieldsAndReset < ActiveRecord::Migration
+class AddPartnerSmsFieldsAndReset < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :short_code, :string
     add_column :partners, :terms_url, :string

--- a/db/migrate/20200311172157_create_state_registrants_mi_registrants.rb
+++ b/db/migrate/20200311172157_create_state_registrants_mi_registrants.rb
@@ -1,4 +1,4 @@
-class CreateStateRegistrantsMiRegistrants < ActiveRecord::Migration
+class CreateStateRegistrantsMiRegistrants < ActiveRecord::Migration[4.2]
   def change
     create_table :state_registrants_mi_registrants do |t|
       t.string  :registrant_id

--- a/db/migrate/20200320150251_update_mi_registrants_with_status_fields.rb
+++ b/db/migrate/20200320150251_update_mi_registrants_with_status_fields.rb
@@ -1,4 +1,4 @@
-class UpdateMiRegistrantsWithStatusFields < ActiveRecord::Migration
+class UpdateMiRegistrantsWithStatusFields < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_mi_registrants, :mi_api_voter_status_id, :string
   end

--- a/db/migrate/20200322002933_create_request_logs.rb
+++ b/db/migrate/20200322002933_create_request_logs.rb
@@ -1,4 +1,4 @@
-class CreateRequestLogs < ActiveRecord::Migration
+class CreateRequestLogs < ActiveRecord::Migration[4.2]
   def change
     create_table :request_logs do |t|
       t.string :client_id, index: true

--- a/db/migrate/20200327150005_add_post_directional_to_mi_registrants.rb
+++ b/db/migrate/20200327150005_add_post_directional_to_mi_registrants.rb
@@ -1,4 +1,4 @@
-class AddPostDirectionalToMiRegistrants < ActiveRecord::Migration
+class AddPostDirectionalToMiRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_mi_registrants, :registration_address_post_directional, :string
   end

--- a/db/migrate/20200327163329_add_registration_address_matches_to_mi_registrants.rb
+++ b/db/migrate/20200327163329_add_registration_address_matches_to_mi_registrants.rb
@@ -1,4 +1,4 @@
-class AddRegistrationAddressMatchesToMiRegistrants < ActiveRecord::Migration
+class AddRegistrationAddressMatchesToMiRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_mi_registrants, :registration_address_matches, :text
   end

--- a/db/migrate/20200505141627_create_canvassing_shifts.rb
+++ b/db/migrate/20200505141627_create_canvassing_shifts.rb
@@ -1,4 +1,4 @@
-class CreateCanvassingShifts < ActiveRecord::Migration
+class CreateCanvassingShifts < ActiveRecord::Migration[4.2]
   def change
     create_table :canvassing_shifts do |t|
       t.integer :partner_id

--- a/db/migrate/20200505143617_create_canvassing_shift_registrants.rb
+++ b/db/migrate/20200505143617_create_canvassing_shift_registrants.rb
@@ -1,4 +1,4 @@
-class CreateCanvassingShiftRegistrants < ActiveRecord::Migration
+class CreateCanvassingShiftRegistrants < ActiveRecord::Migration[4.2]
   def change
     create_table :canvassing_shift_registrants do |t|
       t.string :registrant_id

--- a/db/migrate/20200505154447_create_canvassing_shift_grommet_requests.rb
+++ b/db/migrate/20200505154447_create_canvassing_shift_grommet_requests.rb
@@ -1,4 +1,4 @@
-class CreateCanvassingShiftGrommetRequests < ActiveRecord::Migration
+class CreateCanvassingShiftGrommetRequests < ActiveRecord::Migration[4.2]
   def change
     create_table :canvassing_shift_grommet_requests do |t|
       t.string :grommet_request_id

--- a/db/migrate/20200506180850_create_blocks_service_bulk_submissions.rb
+++ b/db/migrate/20200506180850_create_blocks_service_bulk_submissions.rb
@@ -1,4 +1,4 @@
-class CreateBlocksServiceBulkSubmissions < ActiveRecord::Migration
+class CreateBlocksServiceBulkSubmissions < ActiveRecord::Migration[4.2]
   def change
     create_table :blocks_service_bulk_submissions do |t|
       t.datetime :shift_start

--- a/db/migrate/20200512195429_add_submitted_to_blocks_to_canvassing_shifts.rb
+++ b/db/migrate/20200512195429_add_submitted_to_blocks_to_canvassing_shifts.rb
@@ -1,4 +1,4 @@
-class AddSubmittedToBlocksToCanvassingShifts < ActiveRecord::Migration
+class AddSubmittedToBlocksToCanvassingShifts < ActiveRecord::Migration[4.2]
   def change
     add_column :canvassing_shifts, :submitted_to_blocks, :boolean, default: false
   end

--- a/db/migrate/20200514140305_create_blocks_form_dispositions.rb
+++ b/db/migrate/20200514140305_create_blocks_form_dispositions.rb
@@ -1,4 +1,4 @@
-class CreateBlocksFormDispositions < ActiveRecord::Migration
+class CreateBlocksFormDispositions < ActiveRecord::Migration[4.2]
   def change
     create_table :blocks_form_dispositions do |t|
       t.integer :grommet_request_id, index: true

--- a/db/migrate/20200515160823_change_canvasser_name_fields.rb
+++ b/db/migrate/20200515160823_change_canvasser_name_fields.rb
@@ -1,4 +1,4 @@
-class ChangeCanvasserNameFields < ActiveRecord::Migration
+class ChangeCanvasserNameFields < ActiveRecord::Migration[4.2]
   def change
     remove_column :canvassing_shifts, :canvasser_name
     add_column :canvassing_shifts, :canvasser_first_name, :string

--- a/db/migrate/20200619180934_add_cron_to_delayed_jobs.rb
+++ b/db/migrate/20200619180934_add_cron_to_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class AddCronToDelayedJobs < ActiveRecord::Migration
+class AddCronToDelayedJobs < ActiveRecord::Migration[4.2]
   def self.up
     add_column :delayed_jobs, :cron, :string
   end

--- a/db/migrate/20200624182013_add_shift_source_to_canvassing_shifts.rb
+++ b/db/migrate/20200624182013_add_shift_source_to_canvassing_shifts.rb
@@ -1,4 +1,4 @@
-class AddShiftSourceToCanvassingShifts < ActiveRecord::Migration
+class AddShiftSourceToCanvassingShifts < ActiveRecord::Migration[4.2]
   def change
     add_column :canvassing_shifts, :shift_source, :string
   end

--- a/db/migrate/20200627194800_create_abrs.rb
+++ b/db/migrate/20200627194800_create_abrs.rb
@@ -1,4 +1,4 @@
-class CreateAbrs < ActiveRecord::Migration
+class CreateAbrs < ActiveRecord::Migration[4.2]
   def change
     create_table :abrs do |t|
       t.string :uid, index: true

--- a/db/migrate/20200703160550_create_catalist_lookups.rb
+++ b/db/migrate/20200703160550_create_catalist_lookups.rb
@@ -1,4 +1,4 @@
-class CreateCatalistLookups < ActiveRecord::Migration
+class CreateCatalistLookups < ActiveRecord::Migration[4.2]
   def change
     create_table :catalist_lookups do |t|
       t.string :first

--- a/db/migrate/20200703200105_update_blocks_form_dispositions_blocks_form_id.rb
+++ b/db/migrate/20200703200105_update_blocks_form_dispositions_blocks_form_id.rb
@@ -1,4 +1,4 @@
-class UpdateBlocksFormDispositionsBlocksFormId < ActiveRecord::Migration
+class UpdateBlocksFormDispositionsBlocksFormId < ActiveRecord::Migration[4.2]
   def change
     change_column :blocks_form_dispositions, :blocks_form_id, :string
   end

--- a/db/migrate/20200707144509_create_abrs_catalist_lookups.rb
+++ b/db/migrate/20200707144509_create_abrs_catalist_lookups.rb
@@ -1,4 +1,4 @@
-class CreateAbrsCatalistLookups < ActiveRecord::Migration
+class CreateAbrsCatalistLookups < ActiveRecord::Migration[4.2]
   def change
     create_table :abrs_catalist_lookups do |t|
       t.integer :abr_id, index: true

--- a/db/migrate/20200707151826_add_mailing_address_to_abrs.rb
+++ b/db/migrate/20200707151826_add_mailing_address_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddMailingAddressToAbrs < ActiveRecord::Migration
+class AddMailingAddressToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :mailing_address, :string
     add_column :abrs, :mailing_city, :string

--- a/db/migrate/20200707152406_add_abr_fields_to_abrs.rb
+++ b/db/migrate/20200707152406_add_abr_fields_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddAbrFieldsToAbrs < ActiveRecord::Migration
+class AddAbrFieldsToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :state_id_number, :string
     add_column :abrs, :party, :string

--- a/db/migrate/20200707195747_add_has_mailing_address_to_abrs.rb
+++ b/db/migrate/20200707195747_add_has_mailing_address_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddHasMailingAddressToAbrs < ActiveRecord::Migration
+class AddHasMailingAddressToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :has_mailing_address, :boolean
   end

--- a/db/migrate/20200708163438_add_abr_id_to_request_logs.rb
+++ b/db/migrate/20200708163438_add_abr_id_to_request_logs.rb
@@ -1,4 +1,4 @@
-class AddAbrIdToRequestLogs < ActiveRecord::Migration
+class AddAbrIdToRequestLogs < ActiveRecord::Migration[4.2]
   def change
     add_column :request_logs, :abr_id, :string, index: true
   end

--- a/db/migrate/20200709013325_add_match_to_catalist_lookups.rb
+++ b/db/migrate/20200709013325_add_match_to_catalist_lookups.rb
@@ -1,4 +1,4 @@
-class AddMatchToCatalistLookups < ActiveRecord::Migration
+class AddMatchToCatalistLookups < ActiveRecord::Migration[4.2]
   def change
     add_column :catalist_lookups, :match, :text
   end

--- a/db/migrate/20200709124025_add_votercheck_to_abrs.rb
+++ b/db/migrate/20200709124025_add_votercheck_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddVotercheckToAbrs < ActiveRecord::Migration
+class AddVotercheckToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :votercheck, :string
   end

--- a/db/migrate/20200709124143_add_enabled_for_catalist_api_to_partners.rb
+++ b/db/migrate/20200709124143_add_enabled_for_catalist_api_to_partners.rb
@@ -1,4 +1,4 @@
-class AddEnabledForCatalistApiToPartners < ActiveRecord::Migration
+class AddEnabledForCatalistApiToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :enabled_for_catalist_api, :boolean
   end

--- a/db/migrate/20200709125210_add_current_step_to_abrs.rb
+++ b/db/migrate/20200709125210_add_current_step_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddCurrentStepToAbrs < ActiveRecord::Migration
+class AddCurrentStepToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :current_step, :string, index: true
     add_column :abrs, :max_step, :string, index: true

--- a/db/migrate/20200709192000_update_request_logs_request_uri.rb
+++ b/db/migrate/20200709192000_update_request_logs_request_uri.rb
@@ -1,4 +1,4 @@
-class UpdateRequestLogsRequestUri < ActiveRecord::Migration
+class UpdateRequestLogsRequestUri < ActiveRecord::Migration[4.2]
   def change
     change_column :request_logs, :request_uri, :text
     change_column :request_logs, :request_headers, :text

--- a/db/migrate/20200714133549_add_blocks_shift_id_to_canvassing_shifts.rb
+++ b/db/migrate/20200714133549_add_blocks_shift_id_to_canvassing_shifts.rb
@@ -1,4 +1,4 @@
-class AddBlocksShiftIdToCanvassingShifts < ActiveRecord::Migration
+class AddBlocksShiftIdToCanvassingShifts < ActiveRecord::Migration[4.2]
   def change
     add_column :canvassing_shifts, :blocks_shift_id, :string, index: true
   end

--- a/db/migrate/20200716170525_add_abandoned_to_abrs.rb
+++ b/db/migrate/20200716170525_add_abandoned_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddAbandonedToAbrs < ActiveRecord::Migration
+class AddAbandonedToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :abandoned, :boolean
   end

--- a/db/migrate/20200716175047_add_pdf_ready_to_abrs.rb
+++ b/db/migrate/20200716175047_add_pdf_ready_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddPdfReadyToAbrs < ActiveRecord::Migration
+class AddPdfReadyToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :pdf_ready, :boolean
     add_column :abrs, :pdf_downloaded, :boolean

--- a/db/migrate/20200724151148_change_abr_address.rb
+++ b/db/migrate/20200724151148_change_abr_address.rb
@@ -1,4 +1,4 @@
-class ChangeAbrAddress < ActiveRecord::Migration
+class ChangeAbrAddress < ActiveRecord::Migration[4.2]
   def change
     remove_column :abrs, :address
     add_column :abrs, :street_number, :string

--- a/db/migrate/20200724152137_create_abr_state_values.rb
+++ b/db/migrate/20200724152137_create_abr_state_values.rb
@@ -1,4 +1,4 @@
-class CreateAbrStateValues < ActiveRecord::Migration
+class CreateAbrStateValues < ActiveRecord::Migration[4.2]
   def change
     create_table :abr_state_values do |t|
       t.integer :abr_id, index: true

--- a/db/migrate/20200724190719_cleanup_unused_abr_fields.rb
+++ b/db/migrate/20200724190719_cleanup_unused_abr_fields.rb
@@ -1,4 +1,4 @@
-class CleanupUnusedAbrFields < ActiveRecord::Migration
+class CleanupUnusedAbrFields < ActiveRecord::Migration[4.2]
   def change
     remove_column :abrs, :gender
     remove_column :abrs, :mailing_address

--- a/db/migrate/20200727143305_create_pdf_abr_generations.rb
+++ b/db/migrate/20200727143305_create_pdf_abr_generations.rb
@@ -1,4 +1,4 @@
-class CreatePdfAbrGenerations < ActiveRecord::Migration
+class CreatePdfAbrGenerations < ActiveRecord::Migration[4.2]
   def change
     create_table :pdf_abr_generations do |t|
       t.integer :abr_id

--- a/db/migrate/20200729171329_add_complete_to_canvassing_shifts.rb
+++ b/db/migrate/20200729171329_add_complete_to_canvassing_shifts.rb
@@ -1,4 +1,4 @@
-class AddCompleteToCanvassingShifts < ActiveRecord::Migration
+class AddCompleteToCanvassingShifts < ActiveRecord::Migration[4.2]
   def change
     add_column :canvassing_shifts, :complete, :boolean
   end

--- a/db/migrate/20200730145155_add_blocks_shift_location_name_to_canvassing_shifts.rb
+++ b/db/migrate/20200730145155_add_blocks_shift_location_name_to_canvassing_shifts.rb
@@ -1,4 +1,4 @@
-class AddBlocksShiftLocationNameToCanvassingShifts < ActiveRecord::Migration
+class AddBlocksShiftLocationNameToCanvassingShifts < ActiveRecord::Migration[4.2]
   def change
     add_column :canvassing_shifts, :blocks_shift_location_name, :string
   end

--- a/db/migrate/20200730182010_add_has_fields_to_mi_registrants.rb
+++ b/db/migrate/20200730182010_add_has_fields_to_mi_registrants.rb
@@ -1,4 +1,4 @@
-class AddHasFieldsToMiRegistrants < ActiveRecord::Migration
+class AddHasFieldsToMiRegistrants < ActiveRecord::Migration[4.2]
   def change
     add_column :state_registrants_mi_registrants, :has_ssn, :boolean, default: false
     add_column :state_registrants_mi_registrants, :has_state_license, :boolean, default: false

--- a/db/migrate/20200802203938_create_voter_signatures.rb
+++ b/db/migrate/20200802203938_create_voter_signatures.rb
@@ -1,4 +1,4 @@
-class CreateVoterSignatures < ActiveRecord::Migration
+class CreateVoterSignatures < ActiveRecord::Migration[4.2]
   def change
     create_table :voter_signatures do |t|
       t.string :registrant_id, index: true

--- a/db/migrate/20200803151653_add_finish_with_state_to_abrs.rb
+++ b/db/migrate/20200803151653_add_finish_with_state_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddFinishWithStateToAbrs < ActiveRecord::Migration
+class AddFinishWithStateToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :finish_with_state, :boolean, default: false
   end

--- a/db/migrate/20200803152343_add_email_status_fileds_to_abrs.rb
+++ b/db/migrate/20200803152343_add_email_status_fileds_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddEmailStatusFiledsToAbrs < ActiveRecord::Migration
+class AddEmailStatusFiledsToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :final_reminder_delivered, :boolean, default: false
     add_column :abrs, :reminders_left, :integer

--- a/db/migrate/20200803181628_set_abrs_abandoned_deafults.rb
+++ b/db/migrate/20200803181628_set_abrs_abandoned_deafults.rb
@@ -1,4 +1,4 @@
-class SetAbrsAbandonedDeafults < ActiveRecord::Migration
+class SetAbrsAbandonedDeafults < ActiveRecord::Migration[4.2]
   def change
     change_column :abrs, :abandoned, :boolean, default: false
     change_column_null :abrs, :abandoned, false, false

--- a/db/migrate/20200805131959_add_dead_end_to_abrs.rb
+++ b/db/migrate/20200805131959_add_dead_end_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddDeadEndToAbrs < ActiveRecord::Migration
+class AddDeadEndToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :dead_end, :boolean, default: false
   end

--- a/db/migrate/20200805132330_add_indexes_to_abrs.rb
+++ b/db/migrate/20200805132330_add_indexes_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddIndexesToAbrs < ActiveRecord::Migration
+class AddIndexesToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_index :abrs, :abandoned
     add_index :abrs, :dead_end

--- a/db/migrate/20200813021009_add_tracking_to_abrs.rb
+++ b/db/migrate/20200813021009_add_tracking_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddTrackingToAbrs < ActiveRecord::Migration
+class AddTrackingToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :tracking_source, :string
     add_column :abrs, :tracking_id, :string

--- a/db/migrate/20200818182446_add_specific_fields_to_zip_code_counties.rb
+++ b/db/migrate/20200818182446_add_specific_fields_to_zip_code_counties.rb
@@ -1,4 +1,4 @@
-class AddSpecificFieldsToZipCodeCounties < ActiveRecord::Migration
+class AddSpecificFieldsToZipCodeCounties < ActiveRecord::Migration[4.2]
   def change
     add_column :zip_code_county_addresses, :vr_address_to, :string
     add_column :zip_code_county_addresses, :vr_street1, :string

--- a/db/migrate/20200820125421_add_registrar_abr_address_to_geo_states.rb
+++ b/db/migrate/20200820125421_add_registrar_abr_address_to_geo_states.rb
@@ -1,4 +1,4 @@
-class AddRegistrarAbrAddressToGeoStates < ActiveRecord::Migration
+class AddRegistrarAbrAddressToGeoStates < ActiveRecord::Migration[4.2]
   def change
     add_column :geo_states, :registrar_abr_address, :string
   end

--- a/db/migrate/20200903143849_add_abr_id_to_voter_signatures.rb
+++ b/db/migrate/20200903143849_add_abr_id_to_voter_signatures.rb
@@ -1,4 +1,4 @@
-class AddAbrIdToVoterSignatures < ActiveRecord::Migration
+class AddAbrIdToVoterSignatures < ActiveRecord::Migration[4.2]
   def change
     add_column :voter_signatures, :abr_id, :integer, index: true
   end

--- a/db/migrate/20200908022001_add_registration_county_to_abrs.rb
+++ b/db/migrate/20200908022001_add_registration_county_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddRegistrationCountyToAbrs < ActiveRecord::Migration
+class AddRegistrationCountyToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :registration_county, :string
   end

--- a/db/migrate/20200908025712_add_status_check_url_to_geo_states.rb
+++ b/db/migrate/20200908025712_add_status_check_url_to_geo_states.rb
@@ -1,4 +1,4 @@
-class AddStatusCheckUrlToGeoStates < ActiveRecord::Migration
+class AddStatusCheckUrlToGeoStates < ActiveRecord::Migration[4.2]
   def change
     add_column :geo_states, :status_check_url, :string
   end

--- a/db/migrate/20200908184008_add_confirm_email_delivery_to_abrs.rb
+++ b/db/migrate/20200908184008_add_confirm_email_delivery_to_abrs.rb
@@ -1,4 +1,4 @@
-class AddConfirmEmailDeliveryToAbrs < ActiveRecord::Migration
+class AddConfirmEmailDeliveryToAbrs < ActiveRecord::Migration[4.2]
   def change
     add_column :abrs, :confirm_email_delivery, :boolean
   end

--- a/db/migrate/20200914112538_create_pdf_delivery_reports.rb
+++ b/db/migrate/20200914112538_create_pdf_delivery_reports.rb
@@ -1,4 +1,4 @@
-class CreatePdfDeliveryReports < ActiveRecord::Migration
+class CreatePdfDeliveryReports < ActiveRecord::Migration[4.2]
   def change
     create_table :pdf_delivery_reports do |t|
       t.date :date, index: true

--- a/db/migrate/20200915133334_add_blocks_turf_id_to_canvassing_shifts.rb
+++ b/db/migrate/20200915133334_add_blocks_turf_id_to_canvassing_shifts.rb
@@ -1,4 +1,4 @@
-class AddBlocksTurfIdToCanvassingShifts < ActiveRecord::Migration
+class AddBlocksTurfIdToCanvassingShifts < ActiveRecord::Migration[4.2]
   def change
     add_column :canvassing_shifts, :blocks_turf_id, :string
   end

--- a/db/migrate/20200918163335_create_abr_email_deliveries.rb
+++ b/db/migrate/20200918163335_create_abr_email_deliveries.rb
@@ -1,4 +1,4 @@
-class CreateAbrEmailDeliveries < ActiveRecord::Migration
+class CreateAbrEmailDeliveries < ActiveRecord::Migration[4.2]
   def change
     create_table :abr_email_deliveries do |t|
       t.integer :abr_id, index: true

--- a/db/migrate/20200920131652_add_pdf_assistance_enabled_to_geo_states.rb
+++ b/db/migrate/20200920131652_add_pdf_assistance_enabled_to_geo_states.rb
@@ -1,4 +1,4 @@
-class AddPdfAssistanceEnabledToGeoStates < ActiveRecord::Migration
+class AddPdfAssistanceEnabledToGeoStates < ActiveRecord::Migration[4.2]
   def change
     add_column :geo_states, :pdf_assistance_enabled, :boolean
   end

--- a/db/migrate/20200920135138_add_states_enabled_for_pdf_assistance_to_partners.rb
+++ b/db/migrate/20200920135138_add_states_enabled_for_pdf_assistance_to_partners.rb
@@ -1,4 +1,4 @@
-class AddStatesEnabledForPdfAssistanceToPartners < ActiveRecord::Migration
+class AddStatesEnabledForPdfAssistanceToPartners < ActiveRecord::Migration[4.2]
   def change
     add_column :partners, :states_enabled_for_pdf_assistance, :text
   end

--- a/db/migrate/20200922165546_add_partner_id_and_tracking_to_catalist_lookups.rb
+++ b/db/migrate/20200922165546_add_partner_id_and_tracking_to_catalist_lookups.rb
@@ -1,4 +1,4 @@
-class AddPartnerIdAndTrackingToCatalistLookups < ActiveRecord::Migration
+class AddPartnerIdAndTrackingToCatalistLookups < ActiveRecord::Migration[4.2]
   def change
     add_column :catalist_lookups, :partner_id, :integer
     add_column :catalist_lookups, :tracking_source, :string

--- a/db/migrate/20200922172247_add_uid_to_catalist_lookups.rb
+++ b/db/migrate/20200922172247_add_uid_to_catalist_lookups.rb
@@ -1,4 +1,4 @@
-class AddUidToCatalistLookups < ActiveRecord::Migration
+class AddUidToCatalistLookups < ActiveRecord::Migration[4.2]
   def change
     add_column :catalist_lookups, :uid, :string, index: true
   end

--- a/db/migrate/20200922180512_add_catalist_updated_at_to_geo_states.rb
+++ b/db/migrate/20200922180512_add_catalist_updated_at_to_geo_states.rb
@@ -1,4 +1,4 @@
-class AddCatalistUpdatedAtToGeoStates < ActiveRecord::Migration
+class AddCatalistUpdatedAtToGeoStates < ActiveRecord::Migration[4.2]
   def change
     add_column :geo_states, :catalist_updated_at, :date
   end

--- a/db/migrate/20200922185732_add_phone_type_to_catalist_lookups.rb
+++ b/db/migrate/20200922185732_add_phone_type_to_catalist_lookups.rb
@@ -1,4 +1,4 @@
-class AddPhoneTypeToCatalistLookups < ActiveRecord::Migration
+class AddPhoneTypeToCatalistLookups < ActiveRecord::Migration[4.2]
   def change
     add_column :catalist_lookups, :phone_type, :string
   end

--- a/db/migrate/20200922195536_add_opt_ins_to_catalist_lookups.rb
+++ b/db/migrate/20200922195536_add_opt_ins_to_catalist_lookups.rb
@@ -1,4 +1,4 @@
-class AddOptInsToCatalistLookups < ActiveRecord::Migration
+class AddOptInsToCatalistLookups < ActiveRecord::Migration[4.2]
   def change
     add_column "catalist_lookups", "opt_in_email", :boolean
     add_column "catalist_lookups", "opt_in_sms", :boolean

--- a/db/migrate/20200929202144_create_blocks_locations.rb
+++ b/db/migrate/20200929202144_create_blocks_locations.rb
@@ -1,4 +1,4 @@
-class CreateBlocksLocations < ActiveRecord::Migration
+class CreateBlocksLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :blocks_locations do |t|
       t.string :blocks_id, index: true

--- a/db/migrate/20201015154203_create_catalist_lookups_registrants.rb
+++ b/db/migrate/20201015154203_create_catalist_lookups_registrants.rb
@@ -1,4 +1,4 @@
-class CreateCatalistLookupsRegistrants < ActiveRecord::Migration
+class CreateCatalistLookupsRegistrants < ActiveRecord::Migration[4.2]
   def change
     create_table :catalist_lookups_registrants do |t|
       t.string :registrant_uid, index: true

--- a/db/migrate/20201028204122_add_phones_and_emails_to_zip_code_county_addresses.rb
+++ b/db/migrate/20201028204122_add_phones_and_emails_to_zip_code_county_addresses.rb
@@ -1,4 +1,4 @@
-class AddPhonesAndEmailsToZipCodeCountyAddresses < ActiveRecord::Migration
+class AddPhonesAndEmailsToZipCodeCountyAddresses < ActiveRecord::Migration[4.2]
   def change
     add_column :zip_code_county_addresses, :vr_contact_email, :string
     add_column :zip_code_county_addresses, :vr_contact_phone, :string

--- a/db/migrate/20201029001614_add_contact_info_to_zip_code_county_addresses.rb
+++ b/db/migrate/20201029001614_add_contact_info_to_zip_code_county_addresses.rb
@@ -1,4 +1,4 @@
-class AddContactInfoToZipCodeCountyAddresses < ActiveRecord::Migration
+class AddContactInfoToZipCodeCountyAddresses < ActiveRecord::Migration[4.2]
   def change
     add_column :zip_code_county_addresses, :vr_contact_office_name, :string
     add_column :zip_code_county_addresses, :vr_contact_title, :string

--- a/db/migrate/20201029003849_create_ballot_status_checks.rb
+++ b/db/migrate/20201029003849_create_ballot_status_checks.rb
@@ -1,4 +1,4 @@
-class CreateBallotStatusChecks < ActiveRecord::Migration
+class CreateBallotStatusChecks < ActiveRecord::Migration[4.2]
   def change
     create_table :ballot_status_checks do |t|
       t.string :first_name

--- a/db/migrate/20201029141725_add_main_phone_email_to_zip_code_county_addresses.rb
+++ b/db/migrate/20201029141725_add_main_phone_email_to_zip_code_county_addresses.rb
@@ -1,4 +1,4 @@
-class AddMainPhoneEmailToZipCodeCountyAddresses < ActiveRecord::Migration
+class AddMainPhoneEmailToZipCodeCountyAddresses < ActiveRecord::Migration[4.2]
   def change
     add_column :zip_code_county_addresses, :vr_main_phone, :string
     add_column :zip_code_county_addresses, :vr_main_email, :string


### PR DESCRIPTION
Rails5 Directly inheriting from ActiveRecord::Migration is not supported.

This update modifies the migrations that are missing a migration version to 4.2 (the latest version where no version specification was required).


